### PR TITLE
Updated testcontainers version to get fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <slf4j.version>1.7.28</slf4j.version>
     <snakeyaml.version>1.24</snakeyaml.version>
     <otj-pg-embedded.version>0.13.1</otj-pg-embedded.version>
-    <testcontainers.version>1.11.3</testcontainers.version>
+    <testcontainers.version>1.12.5</testcontainers.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Updated testcontainers version to get fix from:
https://github.com/testcontainers/testcontainers-java/pull/2195
Testcontainer .start() command was unable to connect to docker image otherwise.